### PR TITLE
Add scheduling logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ## Development
 
+### Local development with Kubebuilder
+
 1. Install `pre-commit`: see <https://pre-commit.com/#install>
-1. Install `kind`: see <https://kind.sigs.k8s.io/docs/user/quick-start/#installation>
-1. Install `ArgoCD`: see <https://argoproj.github.io/argo-cd/getting_started/>
-1. Install `ApplicationSet` controller: see <https://github.com/argoproj-labs/applicationset>
+1. Install `kubebuilder`: see <https://book.kubebuilder.io/quick-start.html#installation>
 1. Install `ArgoCD Application` API pkg: see `hack/install-argocd-application.sh`
 
 ### Update ArgoCD Application API package

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ apiVersion: deployment.skyscanner.net/v1alpha1
 kind: ProgressiveRollout
 metadata:
   name: myprogressiverollout
-  namespace: argoc
+  namespace: argocd
 spec:
   # a reference to the target ApplicationSet
   sourceRef:
@@ -33,10 +33,10 @@ spec:
       # human friendly name
     - name: two clusters as canary in EMEA
       # how many targets to update in parallel
-      # can be an integer or %. Default to 1
+      # can be an integer or %.
       maxParallel: 2
       # how many targets to update from the selector result
-      # can be an integer or %. Default to 100%.
+      # can be an integer or %.
       maxTargets: 2
       # which targets to update
       targets:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ spec:
         clusters:
           selector:
             matchLabels:
-            area: emea
+              area: emea
     - name: rollout to remaining clusters
       maxParallel: 25%
       maxTargets: 100%

--- a/api/v1alpha1/progressiverollout_types.go
+++ b/api/v1alpha1/progressiverollout_types.go
@@ -90,8 +90,8 @@ func (in *ProgressiveRollout) NewStatusCondition(t string, s metav1.ConditionSta
 	}
 }
 
-// IsOwnedBy returns true if the ProgressiveRollout object has a reference to one of the owners
-func (in *ProgressiveRollout) IsOwnedBy(owners []metav1.OwnerReference) bool {
+// Owns returns true if the ProgressiveRollout object has a reference to one of the owners
+func (in *ProgressiveRollout) Owns(owners []metav1.OwnerReference) bool {
 	for _, owner := range owners {
 		if owner.Kind == in.Spec.SourceRef.Kind && owner.APIVersion == *in.Spec.SourceRef.APIGroup && owner.Name == in.Spec.SourceRef.Name {
 			return true

--- a/api/v1alpha1/progressiverollout_types_test.go
+++ b/api/v1alpha1/progressiverollout_types_test.go
@@ -46,7 +46,7 @@ func TestOwns(t *testing.T) {
 
 	for _, testCase := range testCases {
 		got := pr.Owns(testCase.ownerReferences)
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		g.Expect(got).To(Equal(testCase.expected))
 	}
 }

--- a/api/v1alpha1/progressiverollout_types_test.go
+++ b/api/v1alpha1/progressiverollout_types_test.go
@@ -45,7 +45,7 @@ func TestHasOwnerReference(t *testing.T) {
 		}}
 
 	for _, testCase := range testCases {
-		got := pr.IsOwnedBy(testCase.ownerReferences)
+		got := pr.Owns(testCase.ownerReferences)
 		g := NewGomegaWithT(t)
 		g.Expect(got).To(Equal(testCase.expected))
 	}

--- a/api/v1alpha1/progressiverollout_types_test.go
+++ b/api/v1alpha1/progressiverollout_types_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestHasOwnerReference(t *testing.T) {
+func TestOwns(t *testing.T) {
 	testCases := []struct {
 		ownerReferences []metav1.OwnerReference
 		expected        bool

--- a/controllers/progressiverollout_controller.go
+++ b/controllers/progressiverollout_controller.go
@@ -66,12 +66,14 @@ func (r *ProgressiveRolloutReconciler) Reconcile(ctx context.Context, req ctrl.R
 	for _, stage := range pr.Spec.Stages {
 		log = r.Log.WithValues("stage", stage.Name)
 
-		targets, err := r.GetTargetClusters(stage.Targets.Clusters.Selector)
+		targets, err := r.getTargetClusters(stage.Targets.Clusters.Selector)
 		if err != nil {
 			log.Error(err, "unable to fetch targets")
 			return ctrl.Result{}, err
 		}
 		r.Log.V(1).Info("targets selected", "targets", targets.Items)
+
+
 		r.Log.Info("stage completed")
 	}
 
@@ -100,6 +102,7 @@ func (r *ProgressiveRolloutReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		Complete(r)
 }
 
+// requestsForApplicationChange returns a reconcile request for a Progressive Rollout object when an Application change
 func (r *ProgressiveRolloutReconciler) requestsForApplicationChange(o client.Object) []reconcile.Request {
 
 	/*
@@ -135,6 +138,7 @@ func (r *ProgressiveRolloutReconciler) requestsForApplicationChange(o client.Obj
 	return requests
 }
 
+// requestsForSecretChange returns a reconcile request for a Progressive Rollout object when a Secret change
 func (r *ProgressiveRolloutReconciler) requestsForSecretChange(o client.Object) []reconcile.Request {
 
 	/*
@@ -198,8 +202,8 @@ func (r *ProgressiveRolloutReconciler) requestsForSecretChange(o client.Object) 
 	return requests
 }
 
-// GetTargetClusters returns a list of ArgoCD clusters matching the provided label selector
-func (r *ProgressiveRolloutReconciler) GetTargetClusters(selector metav1.LabelSelector) (corev1.SecretList, error) {
+// getTargetClusters returns a list of ArgoCD clusters matching the provided label selector
+func (r *ProgressiveRolloutReconciler) getTargetClusters(selector metav1.LabelSelector) (corev1.SecretList, error) {
 	secrets := corev1.SecretList{}
 	ctx := context.Background()
 

--- a/controllers/progressiverollout_controller.go
+++ b/controllers/progressiverollout_controller.go
@@ -79,7 +79,7 @@ func (r *ProgressiveRolloutReconciler) Reconcile(ctx context.Context, req ctrl.R
 			log.Error(err, "unable to fetch apps")
 			return ctrl.Result{}, err
 		}
-		r.Log.V(1).Info("apps selected", "apps", fmt.Sprintf("%v",apps))
+		r.Log.V(1).Info("apps selected", "apps", fmt.Sprintf("%v", apps))
 
 		syncApps := scheduler.Scheduler(clusters, apps, stage)
 
@@ -247,7 +247,7 @@ func (r *ProgressiveRolloutReconciler) getApps(clusters corev1.SecretList, pr de
 		return apps, err
 	}
 
-	for _, c := range clusters.Items{
+	for _, c := range clusters.Items {
 		for _, app := range appList.Items {
 			if pr.Owns(app.GetOwnerReferences()) && string(c.Data["server"]) == app.Spec.Destination.Server {
 				apps = append(apps, app)

--- a/controllers/progressiverollout_controller.go
+++ b/controllers/progressiverollout_controller.go
@@ -85,7 +85,8 @@ func (r *ProgressiveRolloutReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 		// Remove the annotation from the OutOfSync Applications before passing them to the Scheduler
 		// This action allows the Scheduler to keep track at which stage an Application has been synced.
-		r.removeAnnotationFromApps(&apps, utils.ProgressiveRolloutSyncedAtStageKey)
+		outOfSyncApps := utils.GetAppsBySyncStatusCode(apps, argov1alpha1.SyncStatusCodeOutOfSync)
+		r.removeAnnotationFromApps(&outOfSyncApps, utils.ProgressiveRolloutSyncedAtStageKey)
 
 		// Get the Applications to update
 		scheduledApps := scheduler.Scheduler(apps, stage)

--- a/controllers/progressiverollout_controller.go
+++ b/controllers/progressiverollout_controller.go
@@ -86,7 +86,7 @@ func (r *ProgressiveRolloutReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 		// Remove the annotation from the OutOfSync Applications before passing them to the Scheduler
 		// This action allows the Scheduler to keep track at which stage an Application has been synced.
-		outOfSyncApps := utils.GetAppsBySyncStatusCode(apps, argov1alpha1.SyncStatusCodeOutOfSync)
+		outOfSyncApps := utils.FilterAppsBySyncStatusCode(apps, argov1alpha1.SyncStatusCodeOutOfSync)
 		if err = r.removeAnnotationFromApps(&outOfSyncApps, utils.ProgressiveRolloutSyncedAtStageKey); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/controllers/progressiverollout_controller.go
+++ b/controllers/progressiverollout_controller.go
@@ -124,7 +124,7 @@ func (r *ProgressiveRolloutReconciler) requestsForApplicationChange(o client.Obj
 	}
 
 	for _, pr := range list.Items {
-		if pr.IsOwnedBy(app.GetOwnerReferences()) {
+		if pr.Owns(app.GetOwnerReferences()) {
 			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
 				Namespace: pr.Namespace,
 				Name:      pr.Name,
@@ -174,7 +174,7 @@ func (r *ProgressiveRolloutReconciler) requestsForSecretChange(o client.Object) 
 
 	for _, pr := range prList.Items {
 		for _, app := range appList.Items {
-			if app.Spec.Destination.Server == string(s.Data["server"]) && pr.IsOwnedBy(app.GetOwnerReferences()) {
+			if app.Spec.Destination.Server == string(s.Data["server"]) && pr.Owns(app.GetOwnerReferences()) {
 				/*
 					Consider the following scenario:
 					- 2 Applications

--- a/controllers/progressiverollout_controller.go
+++ b/controllers/progressiverollout_controller.go
@@ -237,6 +237,7 @@ func (r *ProgressiveRolloutReconciler) getClusters(selector metav1.LabelSelector
 	return secrets, nil
 }
 
+// getApps returns a list of Applications targeting the specified clusters and owned by the specified ProgressiveRollout
 func (r *ProgressiveRolloutReconciler) getApps(clusters corev1.SecretList, pr deploymentskyscannernetv1alpha1.ProgressiveRollout) ([]argov1alpha1.Application, error) {
 	apps := []argov1alpha1.Application{{}}
 	appList := argov1alpha1.ApplicationList{}

--- a/controllers/progressiverollout_controller_test.go
+++ b/controllers/progressiverollout_controller_test.go
@@ -221,7 +221,10 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 		It("should reconcile", func() {
 			By("creating a cluster")
 			cluster := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: "single-stage-cluster", Namespace: namespace, Labels: map[string]string{utils.ArgoCDSecretTypeLabel: utils.ArgoCDSecretTypeCluster}}, Data: map[string][]byte{"server": []byte("https://single-stage-pr.kubernetes.io")},
+				ObjectMeta: metav1.ObjectMeta{Name: "single-stage-cluster", Namespace: namespace, Labels: map[string]string{utils.ArgoCDSecretTypeLabel: utils.ArgoCDSecretTypeCluster}},
+				Data: map[string][]byte{
+					"server": []byte("https://single-stage-pr.kubernetes.io"),
+				},
 			}
 			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
 

--- a/controllers/progressiverollout_controller_test.go
+++ b/controllers/progressiverollout_controller_test.go
@@ -219,7 +219,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 
 	Describe("Reconciliation loop", func() {
 		It("should reconcile", func() {
-			By("creating a cluster")
+			By("creating an ArgoCD cluster")
 			cluster := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "single-stage-cluster", Namespace: namespace, Labels: map[string]string{utils.ArgoCDSecretTypeLabel: utils.ArgoCDSecretTypeCluster}},
 				Data: map[string][]byte{

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/argoproj/argo-cd v0.8.1-0.20210218202601-6de3cf44a4cb
+	github.com/argoproj/gitops-engine v0.2.1-0.20210129183711-c5b7114c501f
 	github.com/go-logr/logr v0.3.0
 	github.com/onsi/ginkgo v1.14.2
 	github.com/onsi/gomega v1.10.3

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -12,17 +12,19 @@ import (
 func Scheduler(apps []argov1alpha1.Application, stage deploymentskyscannernetv1alpha1.ProgressiveRolloutStage) []string {
 
 	/*
-		The Scheduler takes
-		- a ProgressiveRolloutStage object
-		- the Applications selected with the clusters selector
+		The Scheduler takes:
+			- a ProgressiveRolloutStage object
+			- the Applications selected with the clusters selector
 
 		The Scheduler splits the Applications in the following groups:
-		- OutOfSync Applications: those are the Applications to update during the stage.
-		- syncedInCurrentStage Applications: those are Application that synced during the current stage. Those Applications count against the number of clusters to update.
-		- progressingApps: those are Applications that are still in progress updating. Those Applications count against the number of clusters to update in parallel.
+			- OutOfSync Applications: those are the Applications to update during the stage.
+			- syncedInCurrentStage Applications: those are Application that synced during the current stage. Those Applications count against the number of clusters to update.
+			- progressingApps: those are Applications that are still in progress updating. Those Applications count against the number of clusters to update in parallel.
 
-		Why does the Scheduler need an annotation? Consider the scenario where we have 5 Applications - 4 OutOfSync and 1 Synced - and a stage with maxTargets = 3.
-		If we don't keep track on which stage the Application synced, we can't compute how many applications we have to update in the current stage. Without the annotation, it would be impossible for the scheduler to know if the Application synced at this stage - and so we have only 2 Applications left to sync.
+		Why does the Scheduler need an annotation?
+		Consider the scenario where we have 5 Applications - 4 OutOfSync and 1 Synced - and a stage with maxTargets = 3.
+		If we don't keep track on which stage the Application synced, we can't compute how many applications we have to update in the current stage.
+		Without the annotation, it would be impossible for the scheduler to know if the Application synced at this stage - and so we have only 2 Applications left to sync.
 	*/
 
 	var scheduledApps []string
@@ -30,7 +32,7 @@ func Scheduler(apps []argov1alpha1.Application, stage deploymentskyscannernetv1a
 	outOfSyncApps := utils.GetAppsBySyncStatusCode(apps, argov1alpha1.SyncStatusCodeOutOfSync)
 
 	// If there are no OutOfSync Applications, return
-	if len(outOfSyncApps) <= 0 {
+	if len(outOfSyncApps) == 0 {
 		return scheduledApps
 	}
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -46,7 +46,9 @@ func Scheduler(apps []argov1alpha1.Application, stage deploymentskyscannernetv1a
 		return scheduledApps
 	}
 
-	// We want to target minimum one cluster
+	// Validation should never allow the user to explicitly use zero values for maxTargets or maxParallel.
+	// Due the rounding down when scaled, they might resolve to 0.
+	// If one of them resolve to 0, we set it to 1.
 	if maxTargets == 0 {
 		maxTargets = 1
 	}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -28,9 +28,7 @@ func Scheduler(apps []argov1alpha1.Application, stage deploymentskyscannernetv1a
 	*/
 
 	var scheduledApps []string
-
 	outOfSyncApps := utils.GetAppsBySyncStatusCode(apps, argov1alpha1.SyncStatusCodeOutOfSync)
-
 	// If there are no OutOfSync Applications, return
 	if len(outOfSyncApps) == 0 {
 		return scheduledApps
@@ -46,6 +44,14 @@ func Scheduler(apps []argov1alpha1.Application, stage deploymentskyscannernetv1a
 	maxParallel, err := intstr.GetScaledValueFromIntOrPercent(&stage.MaxParallel, maxTargets, false)
 	if err != nil {
 		return scheduledApps
+	}
+
+	// We want to target minimum one cluster
+	if maxTargets == 0 {
+		maxTargets = 1
+	}
+	if maxParallel == 0 {
+		maxParallel = 1
 	}
 
 	// If we already synced the desired number of Applications, return

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Scheduler returns a list of apps to sync for a given stage
-func Scheduler(apps []argov1alpha1.Application, stage deploymentskyscannernetv1alpha1.ProgressiveRolloutStage) []string {
+func Scheduler(apps []argov1alpha1.Application, stage deploymentskyscannernetv1alpha1.ProgressiveRolloutStage) []argov1alpha1.Application {
 
 	/*
 		The Scheduler takes:
@@ -27,7 +27,7 @@ func Scheduler(apps []argov1alpha1.Application, stage deploymentskyscannernetv1a
 		Without the annotation, it would be impossible for the scheduler to know if the Application synced at this stage - and so we have only 2 Applications left to sync.
 	*/
 
-	var scheduledApps []string
+	var scheduledApps []argov1alpha1.Application
 	outOfSyncApps := utils.FilterAppsBySyncStatusCode(apps, argov1alpha1.SyncStatusCodeOutOfSync)
 	// If there are no OutOfSync Applications, return
 	if len(outOfSyncApps) == 0 {
@@ -60,7 +60,7 @@ func Scheduler(apps []argov1alpha1.Application, stage deploymentskyscannernetv1a
 	}
 
 	for i := 0; i < maxParallel-len(progressingApps); i++ {
-		scheduledApps = append(scheduledApps, outOfSyncApps[i].Name)
+		scheduledApps = append(scheduledApps, outOfSyncApps[i])
 	}
 	return scheduledApps
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -20,13 +20,16 @@ func Scheduler(apps []argov1alpha1.Application, stage deploymentskyscannernetv1a
 		- OutOfSync Applications: those are the Applications to update during the stage.
 		- syncedInCurrentStage Applications: those are Application that synced during the current stage. Those Applications count against the number of clusters to update.
 		- progressingApps: those are Applications that are still in progress updating. Those Applications count against the number of clusters to update in parallel.
+
+		Why does the Scheduler need an annotation? Consider the scenario where we have 5 Applications - 4 OutOfSync and 1 Synced - and a stage with maxTargets = 3.
+		If we don't keep track on which stage the Application synced, we can't compute how many applications we have to update in the current stage. Without the annotation, it would be impossible for the scheduler to know if the Application synced at this stage - and so we have only 2 Applications left to sync.
 	*/
 
 	var scheduledApps []string
 
 	outOfSyncApps := utils.GetAppsBySyncStatusCode(apps, argov1alpha1.SyncStatusCodeOutOfSync)
 
-	// If there are no Applications out of sync, return
+	// If there are no OutOfSync Applications, return
 	if len(outOfSyncApps) <= 0 {
 		return scheduledApps
 	}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,0 +1,12 @@
+package scheduler
+
+import (
+	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	deploymentskyscannernetv1alpha1 "github.com/Skyscanner/argocd-progressive-rollout/api/v1alpha1"
+)
+
+func Scheduler(clusters corev1.SecretList, apps []argov1alpha1.Application, stage deploymentskyscannernetv1alpha1.ProgressiveRolloutStage) []string {
+	var scheduledApps []string
+	return scheduledApps
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,9 +1,9 @@
 package scheduler
 
 import (
+	deploymentskyscannernetv1alpha1 "github.com/Skyscanner/argocd-progressive-rollout/api/v1alpha1"
 	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	deploymentskyscannernetv1alpha1 "github.com/Skyscanner/argocd-progressive-rollout/api/v1alpha1"
 )
 
 func Scheduler(clusters corev1.SecretList, apps []argov1alpha1.Application, stage deploymentskyscannernetv1alpha1.ProgressiveRolloutStage) []string {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -28,7 +28,7 @@ func Scheduler(apps []argov1alpha1.Application, stage deploymentskyscannernetv1a
 	*/
 
 	var scheduledApps []string
-	outOfSyncApps := utils.GetAppsBySyncStatusCode(apps, argov1alpha1.SyncStatusCodeOutOfSync)
+	outOfSyncApps := utils.FilterAppsBySyncStatusCode(apps, argov1alpha1.SyncStatusCodeOutOfSync)
 	// If there are no OutOfSync Applications, return
 	if len(outOfSyncApps) == 0 {
 		return scheduledApps

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -2,11 +2,43 @@ package scheduler
 
 import (
 	deploymentskyscannernetv1alpha1 "github.com/Skyscanner/argocd-progressive-rollout/api/v1alpha1"
+	"github.com/Skyscanner/argocd-progressive-rollout/internal/utils"
 	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
+	"github.com/argoproj/gitops-engine/pkg/health"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func Scheduler(clusters corev1.SecretList, apps []argov1alpha1.Application, stage deploymentskyscannernetv1alpha1.ProgressiveRolloutStage) []string {
+// Scheduler returns a list of apps to sync
+func Scheduler(apps []argov1alpha1.Application, stage deploymentskyscannernetv1alpha1.ProgressiveRolloutStage) []string {
+
 	var scheduledApps []string
+
+	oufOfSyncApps := utils.GetAppsBySyncStatusCode(apps, argov1alpha1.SyncStatusCodeOutOfSync)
+	progressingApps := utils.GetAppsByHealthStatusCode(apps, health.HealthStatusProgressing)
+
+	maxTargets, err := intstr.GetScaledValueFromIntOrPercent(&stage.MaxTargets, len(oufOfSyncApps), false)
+	if err != nil {
+		return scheduledApps
+	}
+	maxParallel, err := intstr.GetScaledValueFromIntOrPercent(&stage.MaxParallel, maxTargets, false)
+	if err != nil {
+		return scheduledApps
+	}
+
+	if len(oufOfSyncApps) > 0 {
+		for i := 0; i < maxParallel-len(progressingApps); i++ {
+			scheduledApps = append(scheduledApps, oufOfSyncApps[i].Name)
+		}
+	}
 	return scheduledApps
+}
+
+func IsStageComplete(apps []argov1alpha1.Application, stage deploymentskyscannernetv1alpha1.ProgressiveRolloutStage) bool {
+	//TODO: add logic
+	return true
+}
+
+func IsStageFailed(apps []argov1alpha1.Application, stage deploymentskyscannernetv1alpha1.ProgressiveRolloutStage) bool {
+	// TODO: add logic
+	return false
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -12,23 +12,23 @@ import (
 func Scheduler(apps []argov1alpha1.Application, stage deploymentskyscannernetv1alpha1.ProgressiveRolloutStage) []string {
 
 	/*
-	The Scheduler takes
-	- a ProgressiveRolloutStage object
-	- the Applications selected with the clusters selector
+		The Scheduler takes
+		- a ProgressiveRolloutStage object
+		- the Applications selected with the clusters selector
 
-	The Scheduler splits the Applications in the following groups:
-	- OutOfSync Applications: those are the Applications to update during the stage.
-	- syncedInCurrentStage Applications: those are Application that synced during the current stage. Those Applications count against the number of clusters to update.
-	- progressingApps: those are Applications that are still in progress updating. Those Applications count against the number of clusters to update in parallel.
+		The Scheduler splits the Applications in the following groups:
+		- OutOfSync Applications: those are the Applications to update during the stage.
+		- syncedInCurrentStage Applications: those are Application that synced during the current stage. Those Applications count against the number of clusters to update.
+		- progressingApps: those are Applications that are still in progress updating. Those Applications count against the number of clusters to update in parallel.
 	*/
 
 	var scheduledApps []string
 
-	oufOfSyncApps := utils.GetAppsBySyncStatusCode(apps, argov1alpha1.SyncStatusCodeOutOfSync)
+	outOfSyncApps := utils.GetAppsBySyncStatusCode(apps, argov1alpha1.SyncStatusCodeOutOfSync)
 	syncedInCurrentStage := utils.GetSyncedAppsByStage(apps, stage.Name)
 	progressingApps := utils.GetAppsByHealthStatusCode(apps, health.HealthStatusProgressing)
 
-	maxTargets, err := intstr.GetScaledValueFromIntOrPercent(&stage.MaxTargets, len(oufOfSyncApps), false)
+	maxTargets, err := intstr.GetScaledValueFromIntOrPercent(&stage.MaxTargets, len(outOfSyncApps), false)
 	if err != nil {
 		return scheduledApps
 	}
@@ -39,7 +39,7 @@ func Scheduler(apps []argov1alpha1.Application, stage deploymentskyscannernetv1a
 
 	if (maxTargets - len(syncedInCurrentStage)) > 0 {
 		for i := 0; i < maxParallel-len(progressingApps); i++ {
-			scheduledApps = append(scheduledApps, oufOfSyncApps[i].Name)
+			scheduledApps = append(scheduledApps, outOfSyncApps[i].Name)
 		}
 	}
 	return scheduledApps

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -316,6 +316,38 @@ func TestScheduler(t *testing.T) {
 			},
 			expected: nil,
 		},
+		// 1 Applications:
+		//  - OutOfSync 1
+		//  - syncedInCurrentStage 0
+		//  - Progressing 0
+		// Stage:
+		//  - maxTargets: 1
+		//  - maxParallel: 1
+		// The scheduler should return 1 applications
+		{
+			apps: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-one",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+			},
+			stage: deploymentskyscannernetv1alpha1.ProgressiveRolloutStage{
+				Name:        "",
+				MaxParallel: intstr.IntOrString{IntVal: 1},
+				MaxTargets:  intstr.IntOrString{IntVal: 1},
+				Targets:     deploymentskyscannernetv1alpha1.ProgressiveRolloutTargets{},
+			},
+			expected: []string{
+				"app-one",
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -491,7 +491,7 @@ func TestScheduler(t *testing.T) {
 		},
 
 		{
-			name: "Applications: outOfSync 2, syncedInCurrentStage 0, progressing 0, syncedInPreviousStage 1 | Stage: maxTargets 1, maxParallel 1 | Expected: scheduled 1",
+			name: "Applications: outOfSync 2, syncedInCurrentStage 0, progressing 0, syncedInPreviousStage 1 | Stage: maxTargets 2, maxParallel 2 | Expected: scheduled 2",
 			apps: []argov1alpha1.Application{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -523,19 +523,19 @@ func TestScheduler(t *testing.T) {
 					},
 					Status: argov1alpha1.ApplicationStatus{
 						Sync: argov1alpha1.SyncStatus{
-							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+							Status: argov1alpha1.SyncStatusCodeSynced,
 						},
 					},
 				},
 			},
 			stage: deploymentskyscannernetv1alpha1.ProgressiveRolloutStage{
 				Name:        stageName,
-				MaxParallel: intstr.Parse("1"),
-				MaxTargets:  intstr.Parse("1"),
+				MaxParallel: intstr.Parse("2"),
+				MaxTargets:  intstr.Parse("2"),
 				Targets:     deploymentskyscannernetv1alpha1.ProgressiveRolloutTargets{},
 			},
 			expected: []string{
-				"app-one",
+				"app-one", "app-two",
 			},
 		},
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -348,6 +348,82 @@ func TestScheduler(t *testing.T) {
 				"app-one",
 			},
 		},
+		// 5 Applications:
+		//  - OutOfSync 5
+		//  - syncedInCurrentStage 0
+		//  - Progressing 0
+		// Stage:
+		//  - maxTargets: 3
+		//  - maxParallel: 3
+		// The scheduler should return3 applications
+		{
+			apps: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-one",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-two",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-three",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-four",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-five",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+			},
+			stage: deploymentskyscannernetv1alpha1.ProgressiveRolloutStage{
+				Name:        "test-5",
+				MaxParallel: intstr.IntOrString{IntVal: 3},
+				MaxTargets:  intstr.IntOrString{IntVal: 3},
+				Targets:     deploymentskyscannernetv1alpha1.ProgressiveRolloutTargets{},
+			},
+			expected: []string{
+				"app-five", "app-four", "app-one",
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -443,7 +443,7 @@ func TestScheduler(t *testing.T) {
 
 	for _, testCase := range testCases {
 		got := Scheduler(testCase.apps, testCase.stage)
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		g.Expect(got).To(Equal(testCase.expected))
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -700,6 +700,7 @@ func TestScheduler(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			utils.SortAppsByName(&testCase.apps)
 			got := Scheduler(testCase.apps, testCase.stage)
 			g := NewWithT(t)
 			g.Expect(got).To(Equal(testCase.expected))

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -355,7 +355,7 @@ func TestScheduler(t *testing.T) {
 		// Stage:
 		//  - maxTargets: 3
 		//  - maxParallel: 3
-		// The scheduler should return3 applications
+		// The scheduler should return 3 applications
 		{
 			apps: []argov1alpha1.Application{
 				{
@@ -423,6 +423,21 @@ func TestScheduler(t *testing.T) {
 			expected: []string{
 				"app-five", "app-four", "app-one",
 			},
+		},
+		// 0 Applications
+		// Stage:
+		//  - maxTargets: 3
+		//  - maxParallel: 3
+		// The scheduler should return 0 applications
+		{
+			apps: nil,
+			stage: deploymentskyscannernetv1alpha1.ProgressiveRolloutStage{
+				Name:        "test-5",
+				MaxParallel: intstr.IntOrString{IntVal: 3},
+				MaxTargets:  intstr.IntOrString{IntVal: 3},
+				Targets:     deploymentskyscannernetv1alpha1.ProgressiveRolloutTargets{},
+			},
+			expected: nil,
 		},
 	}
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,326 @@
+package scheduler
+
+import (
+	deploymentskyscannernetv1alpha1 "github.com/Skyscanner/argocd-progressive-rollout/api/v1alpha1"
+	"github.com/Skyscanner/argocd-progressive-rollout/internal/utils"
+	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/gitops-engine/pkg/health"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"testing"
+)
+
+func TestScheduler(t *testing.T) {
+	namespace := "default"
+	testCases := []struct {
+		apps     []argov1alpha1.Application
+		stage    deploymentskyscannernetv1alpha1.ProgressiveRolloutStage
+		expected []string
+	}{
+		// 3 Applications:
+		//  - OutOfSync 3
+		//  - syncedInCurrentStage 0
+		//  - Progressing 0
+		// Stage:
+		//  - maxTargets: 2
+		//  - maxParallel: 2
+		// The scheduler should return 2 applications
+		{
+			apps: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-one",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-two",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-three",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+			},
+			stage: deploymentskyscannernetv1alpha1.ProgressiveRolloutStage{
+				Name:        "",
+				MaxParallel: intstr.IntOrString{IntVal: 2},
+				MaxTargets:  intstr.IntOrString{IntVal: 2},
+				Targets:     deploymentskyscannernetv1alpha1.ProgressiveRolloutTargets{},
+			},
+			expected: []string{
+				"app-one", "app-three",
+			},
+		},
+		// 5 Applications:
+		//  - OutOfSync 3
+		//  - syncedInCurrentStage 1
+		//  - Progressing 1
+		// Stage:
+		//  - maxTargets: 5
+		//  - maxParallel: 2
+		// The scheduler should return 1 application
+		{
+			apps: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-one",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-two",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-three",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "app-four",
+						Namespace:   namespace,
+						Annotations: map[string]string{utils.ProgressiveRolloutSyncedAtStageKey: "test-5"},
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "app-five",
+						Namespace:   namespace,
+						Annotations: map[string]string{utils.ProgressiveRolloutSyncedAtStageKey: "test-5"},
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+						Health: argov1alpha1.HealthStatus{Status: health.HealthStatusProgressing},
+					},
+				},
+			},
+			stage: deploymentskyscannernetv1alpha1.ProgressiveRolloutStage{
+				Name:        "test-5",
+				MaxParallel: intstr.IntOrString{IntVal: 2},
+				MaxTargets:  intstr.IntOrString{IntVal: 5},
+				Targets:     deploymentskyscannernetv1alpha1.ProgressiveRolloutTargets{},
+			},
+			expected: []string{
+				"app-one",
+			},
+		},
+		// 5 Applications:
+		//  - OutOfSync 5
+		//  - syncedInCurrentStage 0
+		//  - Progressing 0
+		// Stage:
+		//  - maxTargets: 3
+		//  - maxParallel: 2
+		// The scheduler should return 2 applications
+		{
+			apps: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-one",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-two",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-three",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-four",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-five",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+			},
+			stage: deploymentskyscannernetv1alpha1.ProgressiveRolloutStage{
+				Name:        "test-5",
+				MaxParallel: intstr.IntOrString{IntVal: 2},
+				MaxTargets:  intstr.IntOrString{IntVal: 3},
+				Targets:     deploymentskyscannernetv1alpha1.ProgressiveRolloutTargets{},
+			},
+			expected: []string{
+				"app-five", "app-four",
+			},
+		},
+		// 5 Applications:
+		//  - OutOfSync 2
+		//  - syncedInCurrentStage 3
+		//  - Progressing 0
+		// Stage:
+		//  - maxTargets: 3
+		//  - maxParallel: 1
+		// The scheduler should return 0 applications
+		{
+			apps: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-one",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-two",
+						Namespace: namespace,
+						Annotations: map[string]string{
+							utils.ProgressiveRolloutSyncedAtStageKey: "test-5",
+						},
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusHealthy},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-three",
+						Namespace: namespace,
+						Annotations: map[string]string{
+							utils.ProgressiveRolloutSyncedAtStageKey: "test-5",
+						},
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusHealthy},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-four",
+						Namespace: namespace,
+						Annotations: map[string]string{
+							utils.ProgressiveRolloutSyncedAtStageKey: "test-5",
+						},
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusHealthy},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-five",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+			},
+			stage: deploymentskyscannernetv1alpha1.ProgressiveRolloutStage{
+				Name:        "test-5",
+				MaxParallel: intstr.IntOrString{IntVal: 1},
+				MaxTargets:  intstr.IntOrString{IntVal: 3},
+				Targets:     deploymentskyscannernetv1alpha1.ProgressiveRolloutTargets{},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		got := Scheduler(testCase.apps, testCase.stage)
+		g := NewGomegaWithT(t)
+		g.Expect(got).To(Equal(testCase.expected))
+	}
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -18,7 +18,7 @@ func TestScheduler(t *testing.T) {
 		name     string
 		apps     []argov1alpha1.Application
 		stage    deploymentskyscannernetv1alpha1.ProgressiveRolloutStage
-		expected []string
+		expected []argov1alpha1.Application
 	}{
 		{
 			name: "Applications: outOfSync 3, syncedInCurrentStage 0, progressing 0, | Stage: maxTargets 2, maxParallel 2 | Expected: scheduled 2",
@@ -63,8 +63,29 @@ func TestScheduler(t *testing.T) {
 				MaxTargets:  intstr.Parse("3"),
 				Targets:     deploymentskyscannernetv1alpha1.ProgressiveRolloutTargets{},
 			},
-			expected: []string{
-				"app-one", "app-three",
+			expected: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-one",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-three",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
 			},
 		},
 		{
@@ -135,8 +156,18 @@ func TestScheduler(t *testing.T) {
 				MaxTargets:  intstr.Parse("3"),
 				Targets:     deploymentskyscannernetv1alpha1.ProgressiveRolloutTargets{},
 			},
-			expected: []string{
-				"app-one",
+			expected: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-one",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
 			},
 		},
 		{
@@ -204,8 +235,29 @@ func TestScheduler(t *testing.T) {
 				MaxTargets:  intstr.Parse("3"),
 				Targets:     deploymentskyscannernetv1alpha1.ProgressiveRolloutTargets{},
 			},
-			expected: []string{
-				"app-five", "app-four",
+			expected: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-five",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-four",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
 			},
 		},
 		{
@@ -273,8 +325,29 @@ func TestScheduler(t *testing.T) {
 				MaxTargets:  intstr.Parse("50%"),
 				Targets:     deploymentskyscannernetv1alpha1.ProgressiveRolloutTargets{},
 			},
-			expected: []string{
-				"app-five", "app-four",
+			expected: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-five",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-four",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
 			},
 		},
 		{
@@ -380,8 +453,18 @@ func TestScheduler(t *testing.T) {
 				MaxTargets:  intstr.Parse("1"),
 				Targets:     deploymentskyscannernetv1alpha1.ProgressiveRolloutTargets{},
 			},
-			expected: []string{
-				"app-one",
+			expected: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-one",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
 			},
 		},
 		{
@@ -449,8 +532,40 @@ func TestScheduler(t *testing.T) {
 				MaxTargets:  intstr.Parse("3"),
 				Targets:     deploymentskyscannernetv1alpha1.ProgressiveRolloutTargets{},
 			},
-			expected: []string{
-				"app-five", "app-four", "app-one",
+			expected: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-five",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-four",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-one",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
 			},
 		},
 		{
@@ -485,8 +600,18 @@ func TestScheduler(t *testing.T) {
 				MaxTargets:  intstr.Parse("10%"),
 				Targets:     deploymentskyscannernetv1alpha1.ProgressiveRolloutTargets{},
 			},
-			expected: []string{
-				"app-one",
+			expected: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-one",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
 			},
 		},
 
@@ -534,8 +659,29 @@ func TestScheduler(t *testing.T) {
 				MaxTargets:  intstr.Parse("2"),
 				Targets:     deploymentskyscannernetv1alpha1.ProgressiveRolloutTargets{},
 			},
-			expected: []string{
-				"app-one", "app-two",
+			expected: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-one",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-two",
+						Namespace: namespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
 			},
 		},
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,7 +1,6 @@
 package scheduler
 
 import (
-	"fmt"
 	deploymentskyscannernetv1alpha1 "github.com/Skyscanner/argocd-progressive-rollout/api/v1alpha1"
 	"github.com/Skyscanner/argocd-progressive-rollout/internal/utils"
 	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
@@ -554,9 +553,10 @@ func TestScheduler(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		fmt.Println("Test: ", testCase.name)
-		got := Scheduler(testCase.apps, testCase.stage)
-		g := NewWithT(t)
-		g.Expect(got).To(Equal(testCase.expected))
+		t.Run(testCase.name, func(t *testing.T) {
+			got := Scheduler(testCase.apps, testCase.stage)
+			g := NewWithT(t)
+			g.Expect(got).To(Equal(testCase.expected))
+		})
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -156,8 +156,8 @@ func TestScheduler(t *testing.T) {
 		//  - syncedInCurrentStage 0
 		//  - Progressing 0
 		// Stage:
-		//  - maxTargets: 3
-		//  - maxParallel: 2
+		//  - maxTargets: 50%
+		//  - maxParallel: 100%
 		// The scheduler should return 2 applications
 		{
 			apps: []argov1alpha1.Application{

--- a/internal/utils/consts.go
+++ b/internal/utils/consts.go
@@ -1,9 +1,9 @@
 package utils
 
 const (
-	ArgoCDSecretTypeLabel   = "argocd.argoproj.io/secret-type"
-	ArgoCDSecretTypeCluster = "cluster"
-	AppSetKind              = "ApplicationSet"
-	AppSetAPIGroup          = "argoproj.io/v1alpha1"
-	ProgressiveRolloutStageKey = "apr.skyscanner.net/synced-at-stage"
+	ArgoCDSecretTypeLabel              = "argocd.argoproj.io/secret-type"
+	ArgoCDSecretTypeCluster            = "cluster"
+	AppSetKind                         = "ApplicationSet"
+	AppSetAPIGroup                     = "argoproj.io/v1alpha1"
+	ProgressiveRolloutSyncedAtStageKey = "apr.skyscanner.net/syncedAtStage"
 )

--- a/internal/utils/consts.go
+++ b/internal/utils/consts.go
@@ -5,4 +5,5 @@ const (
 	ArgoCDSecretTypeCluster = "cluster"
 	AppSetKind              = "ApplicationSet"
 	AppSetAPIGroup          = "argoproj.io/v1alpha1"
+	ProgressiveRolloutStageKey = "apr.skyscanner.net/synced-at-stage"
 )

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -33,8 +33,6 @@ func FilterAppsBySyncStatusCode(apps []argov1alpha1.Application, code argov1alph
 		}
 	}
 
-	SortAppsByName(&result)
-
 	return result
 }
 
@@ -47,8 +45,6 @@ func GetAppsByHealthStatusCode(apps []argov1alpha1.Application, code health.Heal
 			result = append(result, app)
 		}
 	}
-
-	SortAppsByName(&result)
 
 	return result
 }
@@ -63,8 +59,6 @@ func GetSyncedAppsByStage(apps []argov1alpha1.Application, name string) []argov1
 			result = append(result, app)
 		}
 	}
-
-	SortAppsByName(&result)
 
 	return result
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -23,8 +23,8 @@ func SortAppsByName(apps *[]argov1alpha1.Application) {
 	sort.SliceStable(*apps, func(i, j int) bool { return (*apps)[i].Name < (*apps)[j].Name })
 }
 
-// GetAppsBySyncStatusCode returns the Applications matching the specified sync status code
-func GetAppsBySyncStatusCode(apps []argov1alpha1.Application, code argov1alpha1.SyncStatusCode) []argov1alpha1.Application {
+// FilterAppsBySyncStatusCode returns the Applications matching the specified sync status code
+func FilterAppsBySyncStatusCode(apps []argov1alpha1.Application, code argov1alpha1.SyncStatusCode) []argov1alpha1.Application {
 	var result []argov1alpha1.Application
 
 	for _, app := range apps {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -33,6 +33,8 @@ func GetAppsBySyncStatusCode(apps []argov1alpha1.Application, code argov1alpha1.
 		}
 	}
 
+	SortAppsByName(&result)
+
 	return result
 }
 
@@ -45,6 +47,24 @@ func GetAppsByHealthStatusCode(apps []argov1alpha1.Application, code health.Heal
 			result = append(result, app)
 		}
 	}
+
+	SortAppsByName(&result)
+
+	return result
+}
+
+// GetSyncedAppsByStage returns the Applications that synced during the given stage
+func GetSyncedAppsByStage(apps []argov1alpha1.Application, name string) []argov1alpha1.Application {
+	var result []argov1alpha1.Application
+
+	for _, app := range apps {
+		val, ok := app.Annotations[ProgressiveRolloutStageKey]
+		if ok && val == name && app.Status.Sync.Status == argov1alpha1.SyncStatusCodeSynced {
+			result = append(result, app)
+		}
+	}
+
+	SortAppsByName(&result)
 
 	return result
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -58,8 +58,8 @@ func GetSyncedAppsByStage(apps []argov1alpha1.Application, name string) []argov1
 	var result []argov1alpha1.Application
 
 	for _, app := range apps {
-		val, ok := app.Annotations[ProgressiveRolloutStageKey]
-		if ok && val == name && app.Status.Sync.Status == argov1alpha1.SyncStatusCodeSynced {
+		val, ok := app.Annotations[ProgressiveRolloutSyncedAtStageKey]
+		if ok && val == name && app.Status.Sync.Status == argov1alpha1.SyncStatusCodeSynced && app.Status.Health.Status == health.HealthStatusHealthy {
 			result = append(result, app)
 		}
 	}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/gitops-engine/pkg/health"
 	corev1 "k8s.io/api/core/v1"
 	"sort"
 )
@@ -20,4 +21,30 @@ func SortSecretsByName(secrets *corev1.SecretList) {
 // SortSecretsByName sort the Application slice in place by the app name
 func SortAppsByName(apps *[]argov1alpha1.Application) {
 	sort.SliceStable(*apps, func(i, j int) bool { return (*apps)[i].Name < (*apps)[j].Name })
+}
+
+// GetAppsBySyncStatusCode returns the Applications matching the specified sync status code
+func GetAppsBySyncStatusCode(apps []argov1alpha1.Application, code argov1alpha1.SyncStatusCode) []argov1alpha1.Application {
+	var result []argov1alpha1.Application
+
+	for _, app := range apps {
+		if app.Status.Sync.Status == code {
+			result = append(result, app)
+		}
+	}
+
+	return result
+}
+
+// GetAppsByHealthStatusCode returns the Applications matching the specified sync status code
+func GetAppsByHealthStatusCode(apps []argov1alpha1.Application, code health.HealthStatusCode) []argov1alpha1.Application {
+	var result []argov1alpha1.Application
+
+	for _, app := range apps {
+		if app.Status.Health.Status == code {
+			result = append(result, app)
+		}
+	}
+
+	return result
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"sort"
 )
@@ -14,4 +15,9 @@ func IsArgoCDCluster(labels map[string]string) bool {
 // SortSecretsByName sort the SecretList in place by the secrets name
 func SortSecretsByName(secrets *corev1.SecretList) {
 	sort.SliceStable(secrets.Items, func(i, j int) bool { return secrets.Items[i].Name < secrets.Items[j].Name })
+}
+
+// SortSecretsByName sort the Application slice in place by the app name
+func SortAppsByName(apps *[]argov1alpha1.Application) {
+	sort.SliceStable(*apps, func(i, j int) bool { return (*apps)[i].Name < (*apps)[j].Name })
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -18,7 +18,7 @@ func SortSecretsByName(secrets *corev1.SecretList) {
 	sort.SliceStable(secrets.Items, func(i, j int) bool { return secrets.Items[i].Name < secrets.Items[j].Name })
 }
 
-// SortSecretsByName sort the Application slice in place by the app name
+// SortAppsByName sort the Application slice in place by the app name
 func SortAppsByName(apps *[]argov1alpha1.Application) {
 	sort.SliceStable(*apps, func(i, j int) bool { return (*apps)[i].Name < (*apps)[j].Name })
 }
@@ -38,7 +38,7 @@ func GetAppsBySyncStatusCode(apps []argov1alpha1.Application, code argov1alpha1.
 	return result
 }
 
-// GetAppsByHealthStatusCode returns the Applications matching the specified sync status code
+// GetAppsByHealthStatusCode returns the Applications matching the specified health status code
 func GetAppsByHealthStatusCode(apps []argov1alpha1.Application, code health.HealthStatusCode) []argov1alpha1.Application {
 	var result []argov1alpha1.Application
 

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,4 +58,25 @@ func TestSortSecretsByName(t *testing.T) {
 	g := NewGomegaWithT(t)
 	SortSecretsByName(testCase.secretList)
 	g.Expect(testCase.secretList).Should(Equal(testCase.expected))
+}
+
+func TestSortAppsByName(t *testing.T) {
+	namespace := "default"
+	testCase := struct {
+		apps     *[]argov1alpha1.Application
+		expected *[]argov1alpha1.Application
+	}{
+		apps: &[]argov1alpha1.Application{{
+			ObjectMeta: metav1.ObjectMeta{Name: "appA", Namespace: namespace}}, {
+			ObjectMeta: metav1.ObjectMeta{Name: "appC", Namespace: namespace}}, {
+			ObjectMeta: metav1.ObjectMeta{Name: "appB", Namespace: namespace}}},
+		expected: &[]argov1alpha1.Application{{
+			ObjectMeta: metav1.ObjectMeta{Name: "appA", Namespace: namespace}}, {
+			ObjectMeta: metav1.ObjectMeta{Name: "appB", Namespace: namespace}}, {
+			ObjectMeta: metav1.ObjectMeta{Name: "appC", Namespace: namespace}}},
+	}
+
+	g := NewGomegaWithT(t)
+	SortAppsByName(testCase.apps)
+	g.Expect(testCase.apps).Should(Equal(testCase.expected))
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -31,7 +31,7 @@ func TestIsArgoCDCluster(t *testing.T) {
 
 	for _, testCase := range testCases {
 		got := IsArgoCDCluster(testCase.labels)
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		g.Expect(got).To(Equal(testCase.expected))
 	}
 }
@@ -56,7 +56,7 @@ func TestSortSecretsByName(t *testing.T) {
 		}, {
 			ObjectMeta: metav1.ObjectMeta{Name: "clusterC", Namespace: namespace},
 		}}}}
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	SortSecretsByName(testCase.secretList)
 	g.Expect(testCase.secretList).Should(Equal(testCase.expected))
 }
@@ -77,7 +77,7 @@ func TestSortAppsByName(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "appC", Namespace: namespace}}},
 	}
 
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	SortAppsByName(testCase.apps)
 	g.Expect(testCase.apps).Should(Equal(testCase.expected))
 }
@@ -204,7 +204,7 @@ func TestGetSyncedAppsByStage(t *testing.T) {
 		}}
 
 	for _, testCase := range testCases {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		got := GetSyncedAppsByStage(testCase.apps, testCase.stage)
 		g.Expect(got).Should(Equal(testCase.expected))
 	}


### PR DESCRIPTION
Fix #20

Notes:
- Fix local development instructions with kubebuilder
- Fix indentation in README
- Change the function name to `Owns`, because then when we read `pr.Owns(app.GetOwnersReference())` is clear that the Progressive Rollout owns the Application
- A scheduler that computes which applications we need to updated based on the stage parameters
- Scheduler tests
- New `utils` functions with their tests
- Updated the `should reconcile` integration test to work with the scheduler