### PR TITLE
Temporary push artifacts to Docker Hub

### DIFF
--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -28,12 +28,11 @@ jobs:
     - name: Login to GitHub Packages Docker Registry
       uses: docker/login-action@v1
       with:
-        registry: docker.pkg.github.com
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Build and publish a tagged docker image
       uses: docker/build-push-action@v2
       with:
         push: true
-        tags: docker.pkg.github.com/skyscanner/argocd-progressive-rollout/argocd-progressive-rollout:${{ steps.tagName.outputs.tag }}
+        tags: maruina/argocd-progressive-rollout:${{ steps.tagName.outputs.tag }}

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -44,14 +44,13 @@ jobs:
       - name: Login to GitHub Packages Docker Registry
         uses: docker/login-action@v1
         with:
-          registry: docker.pkg.github.com
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         if: github.event_name != 'pull_request'
 
       - name: Build and publish a docker image when merge in main
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: docker.pkg.github.com/skyscanner/argocd-progressive-rollout/argocd-progressive-rollout:main
+          tags: maruina/argocd-progressive-rollout:main
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
Skyscanner doesn't have a public repository for Docker images when users can pull unauthenticated.

This is blocking https://github.com/Skyscanner/argocd-progressive-rollout/pull/34 as we can't test the Helm chart since we can't pull the docker image.

While we decide where to officially store our open source images, this PR push the docker image to my personal docker hub account. This was agreed internally as it's the fastest way to move forward with this ticket.

I'll raise a separate issue to point this to the official repository once we have one.