### PR TITLE
Publish helm chart on main

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -2,8 +2,8 @@ name: Release Charts
 
 on:
   push:
-    tags:
-      - '*'
+    branches:
+      - main
 
 jobs:
   release-chart:
@@ -27,7 +27,7 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.1.0
         with:
-          charts_dir: chart
+          charts_dir: charts
           version: 1.2.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Fix https://github.com/Skyscanner/argocd-progressive-rollout/pull/34 by

- using the correct chart directory
- publishing the chart when we merge into main