### PR TITLE
Fix helm release

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -27,7 +27,6 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.1.0
         with:
-          charts_dir: charts
-          version: 1.2.0
+          version: v1.2.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Fix https://github.com/Skyscanner/argocd-progressive-rollout/pull/37 by

- removing `charts_dir` since it already defaults to `charts` as per https://github.com/helm/chart-releaser-action/blob/master/cr.sh#L30
- fix `version` as it was missing a `v`
<img width="1303" alt="image" src="https://user-images.githubusercontent.com/4821896/109948898-0cd68700-7cdb-11eb-87f0-232c08b59f65.png">
