### PR TITLE
Allow to reference an existing secret

### DIFF
--- a/.github/workflows/lint-test-chart.yaml
+++ b/.github/workflows/lint-test-chart.yaml
@@ -48,6 +48,12 @@ jobs:
         run: kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-cd/$ARGOCD_VERSION/manifests/crds/application-crd.yaml
         if: steps.list-changed.outputs.changed == 'true'
 
+      - name: Install external secret for chart testing
+        run: |
+          kubectl create namespace argocd
+          kubectl apply -f charts/argocd-progressive-rollout/ci/external-secret.yaml
+        if: steps.list-changed.outputs.changed == 'true'
+
       - name: Run chart-testing (install)
         run: ct install --config ct.yaml
         if: steps.list-changed.outputs.changed == 'true'

--- a/charts/argocd-progressive-rollout/Chart.yaml
+++ b/charts/argocd-progressive-rollout/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4-prealpha
+version: 0.1.5-prealpha
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/argocd-progressive-rollout/README.md
+++ b/charts/argocd-progressive-rollout/README.md
@@ -28,15 +28,16 @@ Users of Helm v2 should use `--set installCRDs=true` to install the CRDs.
 | affinity | object | `{}` |  |
 | args.enableLeaderElection | bool | `false` |  |
 | args.metricsAddr | string | `":8080"` |  |
-| config.argoCDAuthToken | string | `"example-token"` |  |
-| config.argoCDInsecure | string | `"true"` |  |
-| config.argoCDServerAddr | string | `"argocd-server"` |  |
-| configSecret.annotations | object | `{}` |  |
-| configSecret.name | string | `""` |  |
+| config | object | `{"argoCDAuthToken":"example-token","argoCDInsecure":"true","argoCDServerAddr":"argocd-server"}` | Config options |
+| config.argoCDAuthToken | string | `"example-token"` | ArgoCD token |
+| config.argoCDInsecure | string | `"true"` | Allow insecure connection with ArgoCD server |
+| config.argoCDServerAddr | string | `"argocd-server"` | ArgoCD server service address |
+| configSecret | object | `{"annotations":{},"name":""}` | configSecret is a secret object which supplies tokens, configs, etc. |
+| configSecret.name | string | `""` | If this value is not provided, a secret will be generated |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"maruina/argocd-progressive-rollout"` |  |
-| image.tag | string | `""` |  |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` |  |
 | installCRDs | bool | `false` |  |
 | nameOverride | string | `""` |  |
@@ -47,9 +48,9 @@ Users of Helm v2 should use `--set installCRDs=true` to install the CRDs.
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.create | bool | `true` |  |
-| serviceAccount.name | string | `""` |  |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | tolerations | list | `[]` |  |
 
 ----------------------------------------------

--- a/charts/argocd-progressive-rollout/README.md
+++ b/charts/argocd-progressive-rollout/README.md
@@ -1,6 +1,6 @@
 # argocd-progressive-rollout
 
-![Version: 0.1.4-prealpha](https://img.shields.io/badge/Version-0.1.4--prealpha-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main](https://img.shields.io/badge/AppVersion-main-informational?style=flat-square)
+![Version: 0.1.5-prealpha](https://img.shields.io/badge/Version-0.1.5--prealpha-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main](https://img.shields.io/badge/AppVersion-main-informational?style=flat-square)
 
 A Helm chart to install the ArgoCD Progressive Rollout controller.
 
@@ -28,9 +28,10 @@ Users of Helm v2 should use `--set installCRDs=true` to install the CRDs.
 | affinity | object | `{}` |  |
 | args.enableLeaderElection | bool | `false` |  |
 | args.metricsAddr | string | `":8080"` |  |
-| configSecret.argoCDAuthToken | string | `"example-token"` |  |
-| configSecret.argoCDInsecure | string | `"true"` |  |
-| configSecret.argoCDServerAddr | string | `"argocd-server"` |  |
+| config.argoCDAuthToken | string | `"example-token"` |  |
+| config.argoCDInsecure | string | `"true"` |  |
+| config.argoCDServerAddr | string | `"argocd-server"` |  |
+| configSecretName | string | `"prc-config"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"maruina/argocd-progressive-rollout"` |  |

--- a/charts/argocd-progressive-rollout/README.md
+++ b/charts/argocd-progressive-rollout/README.md
@@ -31,7 +31,8 @@ Users of Helm v2 should use `--set installCRDs=true` to install the CRDs.
 | config.argoCDAuthToken | string | `"example-token"` |  |
 | config.argoCDInsecure | string | `"true"` |  |
 | config.argoCDServerAddr | string | `"argocd-server"` |  |
-| configSecretName | string | `"prc-config"` |  |
+| configSecret.annotations | object | `{}` |  |
+| configSecret.name | string | `""` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"maruina/argocd-progressive-rollout"` |  |

--- a/charts/argocd-progressive-rollout/ci/external-secret-values.yaml
+++ b/charts/argocd-progressive-rollout/ci/external-secret-values.yaml
@@ -1,0 +1,2 @@
+configSecret:
+  name: "external-secret"

--- a/charts/argocd-progressive-rollout/ci/external-secret.yaml
+++ b/charts/argocd-progressive-rollout/ci/external-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: external-secret
+  namespace: argocd
+type: Opaque
+data:
+  ARGOCD_AUTH_TOKEN: dG9rZW4=
+  ARGOCD_SERVER_ADDR: YXJnby1jZC1hcmdvY2Qtc2VydmVy
+  ARGOCD_INSECURE: dHJ1ZQ==

--- a/charts/argocd-progressive-rollout/ci/generated-secret-values.yaml
+++ b/charts/argocd-progressive-rollout/ci/generated-secret-values.yaml
@@ -1,0 +1,2 @@
+configSecret:
+  name: ""

--- a/charts/argocd-progressive-rollout/ci/test-values.yaml
+++ b/charts/argocd-progressive-rollout/ci/test-values.yaml
@@ -1,1 +1,0 @@
-configSecretName: ""

--- a/charts/argocd-progressive-rollout/ci/test-values.yaml
+++ b/charts/argocd-progressive-rollout/ci/test-values.yaml
@@ -1,2 +1,1 @@
-configSecret:
-  argoCDAuthToken: "citoken"
+configSecretName: ""

--- a/charts/argocd-progressive-rollout/templates/deployment.yaml
+++ b/charts/argocd-progressive-rollout/templates/deployment.yaml
@@ -22,7 +22,11 @@ spec:
       volumes:
         - name: prc-config
           secret:
+            {{- if .Values.configSecretName }}
+            secretName: {{ .Values.configSecretName }}
+            {{- else }}
             secretName: prc-config
+            {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -50,7 +54,11 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /etc/prcconfig
+              {{- if .Values.configSecretName }}
+              name: {{ .Values.configSecretName }}
+              {{- else }}
               name: prc-config
+              {{- end }}
               readOnly: true
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/argocd-progressive-rollout/templates/deployment.yaml
+++ b/charts/argocd-progressive-rollout/templates/deployment.yaml
@@ -20,12 +20,16 @@ spec:
         {{- include "argocd-progressive-rollout.selectorLabels" . | nindent 8 }}
     spec:
       volumes:
-        - name: prc-config
+        {{- if .Values.configSecret.name }}
+        - name: {{ .Values.configSecret.name }}
+        {{- else }}
+        - name: {{ include "argocd-progressive-rollout.fullname" . }}-config
+        {{- end }}
           secret:
-            {{- if .Values.configSecretName }}
-            secretName: {{ .Values.configSecretName }}
+            {{- if .Values.configSecret.name }}
+            secretName: {{ .Values.configSecret.name }}
             {{- else }}
-            secretName: prc-config
+            secretName: {{ include "argocd-progressive-rollout.fullname" . }}-config
             {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -54,10 +58,10 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /etc/prcconfig
-              {{- if .Values.configSecretName }}
-              name: {{ .Values.configSecretName }}
+              {{- if .Values.configSecret.name }}
+              name: {{ .Values.configSecret.name }}
               {{- else }}
-              name: prc-config
+              name: {{ include "argocd-progressive-rollout.fullname" . }}-config
               {{- end }}
               readOnly: true
       {{- with .Values.nodeSelector }}

--- a/charts/argocd-progressive-rollout/templates/secret.yaml
+++ b/charts/argocd-progressive-rollout/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.configSecretName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  ARGOCD_AUTH_TOKEN: {{ .Values.configSecret.argoCDAuthToken | b64enc }}
-  ARGOCD_SERVER_ADDR: {{ .Values.configSecret.argoCDServerAddr | b64enc }}
-  ARGOCD_INSECURE: {{ .Values.configSecret.argoCDInsecure | b64enc }}
+  ARGOCD_AUTH_TOKEN: {{ .Values.config.argoCDAuthToken | b64enc }}
+  ARGOCD_SERVER_ADDR: {{ .Values.config.argoCDServerAddr | b64enc }}
+  ARGOCD_INSECURE: {{ .Values.config.argoCDInsecure | b64enc }}
+{{- end }}

--- a/charts/argocd-progressive-rollout/templates/secret.yaml
+++ b/charts/argocd-progressive-rollout/templates/secret.yaml
@@ -1,9 +1,13 @@
-{{- if not .Values.configSecretName }}
+{{- if not .Values.configSecret.name }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: prc-config
+  name: {{ include "argocd-progressive-rollout.fullname" . }}-config
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.configSecret.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   ARGOCD_AUTH_TOKEN: {{ .Values.config.argoCDAuthToken | b64enc }}

--- a/charts/argocd-progressive-rollout/values.yaml
+++ b/charts/argocd-progressive-rollout/values.yaml
@@ -9,7 +9,7 @@ installCRDs: false
 image:
   repository: maruina/argocd-progressive-rollout
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
 args:
@@ -21,11 +21,11 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  # -- Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
+  # -- Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
+  # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
@@ -46,7 +46,7 @@ securityContext: {}
   # runAsUser: 1000
 
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
+  # -- We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
@@ -63,13 +63,16 @@ tolerations: []
 
 affinity: {}
 
-# configSecret is a secret object which supplies tokens, configs, etc.
+# -- configSecret is a secret object which supplies tokens, configs, etc.
 configSecret:
-  # If this value is not provided, a secret will be generated
+  # -- If this value is not provided, a secret will be generated
   name: ""
   annotations: {}
-# config options
+# -- Config options
 config:
+  # -- ArgoCD token
   argoCDAuthToken: "example-token"
+  # -- ArgoCD server service address
   argoCDServerAddr: "argocd-server"
+  # -- Allow insecure connection with ArgoCD server
   argoCDInsecure: "true"

--- a/charts/argocd-progressive-rollout/values.yaml
+++ b/charts/argocd-progressive-rollout/values.yaml
@@ -63,9 +63,11 @@ tolerations: []
 
 affinity: {}
 
-# configSecretName is a secret object which supplies tokens, configs, etc.
-# If this value is not provided, a secret will be generated
-configSecretName: "prc-config"
+# configSecret is a secret object which supplies tokens, configs, etc.
+configSecret:
+  # If this value is not provided, a secret will be generated
+  name: ""
+  annotations: {}
 # config options
 config:
   argoCDAuthToken: "example-token"

--- a/charts/argocd-progressive-rollout/values.yaml
+++ b/charts/argocd-progressive-rollout/values.yaml
@@ -63,7 +63,11 @@ tolerations: []
 
 affinity: {}
 
-configSecret:
+# configSecretName is a secret object which supplies tokens, configs, etc.
+# If this value is not provided, a secret will be generated
+configSecretName: "prc-config"
+# config options
+config:
   argoCDAuthToken: "example-token"
   argoCDServerAddr: "argocd-server"
   argoCDInsecure: "true"

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,3 +1,5 @@
 chart-dirs:
   - charts
 target-branch: main
+namespace: argocd
+release-label: argocd-progressive-rollout


### PR DESCRIPTION
We should allow users to reference an existing secret for fetching the operator configuration.

This option allows users to generate the secret in the way they want - using a controller, manually, etc. - without having to store the tokens as clear text in git.