### PR TITLE
Fix flaky test

### DIFF
--- a/controllers/progressiverollout_controller_test.go
+++ b/controllers/progressiverollout_controller_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"testing"
 	"time"
 )
@@ -91,10 +92,12 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 				},
 				Spec: argov1alpha1.ApplicationSpec{},
 			}
-			Expect(k8sClient.Create(ctx, ownedApp)).To(Succeed())
 
-			requests := reconciler.requestsForApplicationChange(ownedApp)
-			Expect(len(requests)).Should(Equal(1))
+			var requests []reconcile.Request
+			Eventually(func() int {
+				requests = reconciler.requestsForApplicationChange(ownedApp)
+				return len(requests)
+			}).Should(Equal(1))
 			Expect(requests[0].NamespacedName).To(Equal(types.NamespacedName{
 				Namespace: namespace,
 				Name:      "owner-pr",
@@ -116,10 +119,11 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 				},
 				Spec: argov1alpha1.ApplicationSpec{},
 			}
-			Expect(k8sClient.Create(ctx, nonOwnedApp)).To(Succeed())
 
-			requests := reconciler.requestsForApplicationChange(nonOwnedApp)
-			Expect(len(requests)).Should(Equal(0))
+			Eventually(func() int {
+				requests := reconciler.requestsForApplicationChange(nonOwnedApp)
+				return len(requests)
+			}).Should(Equal(0))
 		})
 	})
 
@@ -169,10 +173,11 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			cluster := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: namespace, Labels: map[string]string{utils.ArgoCDSecretTypeLabel: utils.ArgoCDSecretTypeCluster}},
 				Data:       map[string][]byte{"server": []byte(serverURL)}}
-			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
 
-			requests := reconciler.requestsForSecretChange(cluster)
-			Expect(len(requests)).Should(Equal(1))
+			Eventually(func() int {
+				requests := reconciler.requestsForSecretChange(cluster)
+				return len(requests)
+			}).Should(Equal(1))
 		})
 
 		It("should not forward an event for a generic secret", func() {
@@ -180,10 +185,9 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			generic := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "generic", Namespace: namespace}, Data: map[string][]byte{"secret": []byte("insecure")},
 			}
-			Expect(k8sClient.Create(ctx, generic)).To(Succeed())
 
-			requests := reconciler.requestsForSecretChange(generic)
 			Eventually(func() int {
+				requests := reconciler.requestsForSecretChange(generic)
 				return len(requests)
 			}).Should(Equal(0))
 		})
@@ -213,10 +217,11 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			internalCluster := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: namespace, Labels: map[string]string{utils.ArgoCDSecretTypeLabel: utils.ArgoCDSecretTypeCluster}},
 				Data:       map[string][]byte{"server": []byte("https://local-kubernetes.default.svc")}}
-			Expect(k8sClient.Create(ctx, internalCluster)).To(Succeed())
 
-			requests := reconciler.requestsForSecretChange(internalCluster)
-			Expect(len(requests)).Should(Equal(0))
+			Eventually(func() int {
+				requests := reconciler.requestsForSecretChange(internalCluster)
+				return len(requests)
+			}).Should(Equal(0))
 		})
 	})
 


### PR DESCRIPTION
Fix https://github.com/Skyscanner/argocd-progressive-rollout/issues/62

Because the k8s API server may not have finished creating the object after our `Create()` call from earlier, we use `Eventually()` testing function instead of `Expect()` to give the API server an opportunity to finish creating the object.

We also remove unnecessary `Create()` since when we call `requestsForApplicationChange` and `requestsForSecretChange` we pass the application and secret as parameter and they don't need to be on the API server.