### PR TITLE
Fixing ginkgo Before race condition

### DIFF
--- a/controllers/progressiverollout_controller_test.go
+++ b/controllers/progressiverollout_controller_test.go
@@ -63,7 +63,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 
 	Describe("requestsForApplicationChange function", func() {
 
-		BeforeEach(func() {
+		JustBeforeEach(func() {
 			ownerPR = &deploymentskyscannernetv1alpha1.ProgressiveRollout{
 				ObjectMeta: metav1.ObjectMeta{Name: "owner-pr", Namespace: namespace},
 				Spec: deploymentskyscannernetv1alpha1.ProgressiveRolloutSpec{
@@ -133,7 +133,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 
 	Describe("requestsForSecretChange function", func() {
 
-		BeforeEach(func() {
+		JustBeforeEach(func() {
 			ownerPR = &deploymentskyscannernetv1alpha1.ProgressiveRollout{
 				ObjectMeta: metav1.ObjectMeta{Name: "owner-pr", Namespace: namespace},
 				Spec: deploymentskyscannernetv1alpha1.ProgressiveRolloutSpec{


### PR DESCRIPTION
The BeforeEach from the context relies on the BeforeEach on the describe
to be completed first;
We had an issue (#81) where this wasn't the case and resulting in
inconsistent testing (flaky).

Using JustBefore will make sure the Context setup will run after the
Describe.

https://onsi.github.io/ginkgo/#separating-creation-and-configuration-justbeforeeach